### PR TITLE
Allow single quotes in SVG style strings

### DIFF
--- a/svg2rlg.py
+++ b/svg2rlg.py
@@ -405,7 +405,7 @@ class SVGStyle(Lexer):
         (delimiter, r'[ :;\n]'),
         (comment, r'/\*.+\*/'),
         (name, r'[\w\-#]+?(?=:)'),
-        (value, r'[\w\-#\.\(\)%,][\w \-#\.\(\)%,]*?(?=[;])'),
+        (value, r"[\w\-#\.\(\)%',][\w \-#\.\(\)%',]*?(?=[;])"),
     )
 
     ignore = frozenset((delimiter, comment))

--- a/test_svg2rlg.py
+++ b/test_svg2rlg.py
@@ -23,13 +23,14 @@ class test_svg2rlg(unittest.TestCase):
     def test_parseStyle(self):
         parse = parseStyle.parse
 
-        txt = 'fill: red; stroke: blue; /* comment */ stroke-width: 3; line-height: 125%'
+        txt = "fill: red; stroke: blue; /* comment */ stroke-width: 3; line-height: 125%;font-family:'Liberation Sans'"
         res = parse(txt)
 
         self.assertTrue(res.pop('fill') == 'red')
         self.assertTrue(res.pop('stroke') == 'blue')
         self.assertTrue(res.pop('stroke-width') == '3')
         self.assertTrue(res.pop('line-height') == '125%')
+        self.assertTrue(res.pop('font-family') == "'Liberation Sans'")
         self.assertTrue(len(res) == 0)
 
     def test_parseTransform(self):


### PR DESCRIPTION
Style attributes containing quoted values, like ```font-family:'Liberation Sans';```, will cause a SVGError with ```"Unknown token at position %d"``` at the moment.

The commit adds support for single quotes to the style parsing grammar.